### PR TITLE
expose snapshot metric

### DIFF
--- a/borel-core.cabal
+++ b/borel-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                borel-core
-version:             0.14.0.0
+version:             0.14.0.1
 synopsis:            Metering System for OpenStack metrics provided by Vaultaire.
 license:             BSD3
 license-file:        LICENSE

--- a/lib/Borel/Types/Metric.hs
+++ b/lib/Borel/Types/Metric.hs
@@ -18,7 +18,7 @@ module Borel.Types.Metric
   , resourceGroups, resourceMeasures
   , allMetrics
     -- * Pre-defined resources
-  , ipTx, ipRx
+  , ipTx, ipRx, snapshot
   , cpu, diskReads, diskWrites, neutronIn, neutronOut
   , computeInstance, ipv4, volumes, vcpus, memory
     -- * Mappings


### PR DESCRIPTION
Is not currently exposed, as with the other metrics.