### PR TITLE
Fixed calculation regarding last points for events

### DIFF
--- a/borel-core.cabal
+++ b/borel-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                borel-core
-version:             0.14.0.2
+version:             0.14.0.3
 synopsis:            Metering System for OpenStack metrics provided by Vaultaire.
 license:             BSD3
 license-file:        LICENSE

--- a/lib/Borel/Aggregate/Ceilometer/Consolidated/Query.hs
+++ b/lib/Borel/Aggregate/Ceilometer/Consolidated/Query.hs
@@ -102,7 +102,10 @@ summarise' rGroup lastEvent acc prod start end isEvent = do
         Left _ -> case lastEvent of
             Nothing -> return M.empty
             Just evt -> if isEvent then do
-                let delta = end - extractTime evt
+                let delta = if extractTime evt < start then
+                                end - start
+                            else
+                                end - extractTime evt
                 let acc' = if not (billableEvent rGroup evt) || delta <= 0
                     then
                         acc


### PR DESCRIPTION
If the last point in a stream of event points had a timestamp before the start time of the query, the summarise fold would use that timestamp, instead of the starting timestamp of the query to fold in the last point.