### PR TITLE
Update Env to add instance status filtering predicate

### DIFF
--- a/borel-core.cabal
+++ b/borel-core.cabal
@@ -1,5 +1,5 @@
 name:                borel-core
-version:             0.16.0
+version:             0.17.0
 synopsis:            Metering System for OpenStack metrics provided by Vaultaire.
 description:         Leverages Ceilometer, Chevalier and Marquise to meter OpenStack data.
 homepage:            https://github.com/anchor/borel-core

--- a/borel-core.cabal
+++ b/borel-core.cabal
@@ -1,5 +1,5 @@
 name:                borel-core
-version:             0.17.0
+version:             0.16.1
 synopsis:            Metering System for OpenStack metrics provided by Vaultaire.
 description:         Leverages Ceilometer, Chevalier and Marquise to meter OpenStack data.
 homepage:            https://github.com/anchor/borel-core

--- a/lib/Borel.hs
+++ b/lib/Borel.hs
@@ -48,6 +48,7 @@ module Borel
   ) where
 
 import           Control.Applicative
+import           Control.Arrow
 import           Control.Lens
 import           Control.Monad.Reader
 import           Data.Set             (Set)
@@ -80,8 +81,10 @@ groupMetrics :: Set Metric        -- ^ All available instances
              -> Set Metric        -- ^ Metrics to be grouped
              -> Set GroupedMetric
 groupMetrics instances metrics
-  =  let (allfs, nonfs) = _1 %~ S.toList $ S.partition (`S.member` instances) metrics
-     in  S.insert allfs $ S.map pure nonfs
+  =  let (allfs, nonfs) = (S.toList *** S.map pure) $ S.partition (`S.member` instances) metrics
+     in case allfs of
+       [] -> nonfs
+       xs -> S.insert xs nonfs
 
 
 --------------------------------------------------------------------------------

--- a/lib/Borel.hs
+++ b/lib/Borel.hs
@@ -130,9 +130,10 @@ query = do
     , (org, addr, sd) <- Select $ chevalier (metrics, params ^. paramTID)
     , result          <- Select $ each' $ ceilometer
                          flavors metrics
-                         (Env flavors sd start end)
+                         (Env flavors sd defaultFilters start end)
                          (marquise params (metrics, org, addr))
     ]
   where each' :: Monad m => m [a] -> Producer a m ()
         each' x = lift x >>= P.each
+        defaultFilters = Filters billableStatus
 

--- a/lib/Borel.hs
+++ b/lib/Borel.hs
@@ -48,7 +48,6 @@ module Borel
   ) where
 
 import           Control.Applicative
-import           Control.Arrow
 import           Control.Lens
 import           Control.Monad.Reader
 import           Data.Set             (Set)
@@ -81,10 +80,8 @@ groupMetrics :: Set Metric        -- ^ All available instances
              -> Set Metric        -- ^ Metrics to be grouped
              -> Set GroupedMetric
 groupMetrics instances metrics
-  =  let (allfs, nonfs) = (S.toList *** S.map pure) $ S.partition (`S.member` instances) metrics
-     in case allfs of
-       [] -> nonfs
-       xs -> S.insert xs nonfs
+  =  let (allfs, nonfs) = _1 %~ S.toList $ S.partition (`S.member` instances) metrics
+     in  S.insert allfs $ S.map pure nonfs
 
 
 --------------------------------------------------------------------------------

--- a/lib/Borel/Ceilometer/Instance.hs
+++ b/lib/Borel/Ceilometer/Instance.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE TupleSections #-}
+
+module Borel.Ceilometer.Instance where
+
+import Ceilometer.Types
+
+billableStatus :: PFInstanceStatus -> Bool
+billableStatus InstanceError            = False
+billableStatus InstanceActive           = True
+billableStatus InstanceShutoff          = False
+billableStatus InstanceBuild            = False
+billableStatus InstanceRebuild          = False
+billableStatus InstanceDeleted          = False
+billableStatus InstanceSoftDeleted      = False
+billableStatus InstanceShelved          = False
+billableStatus InstanceShelvedOffloaded = False
+billableStatus InstanceReboot           = True
+billableStatus InstanceHardReboot       = True
+billableStatus InstancePassword         = True
+billableStatus InstanceResize           = True
+billableStatus InstanceVerifyResize     = True
+billableStatus InstanceRevertResize     = True
+billableStatus InstancePaused           = False
+billableStatus InstanceSuspended        = False
+billableStatus InstanceRescue           = False
+billableStatus InstanceMigrating        = False

--- a/lib/Borel/Ceilometer/Instance.hs
+++ b/lib/Borel/Ceilometer/Instance.hs
@@ -23,4 +23,4 @@ billableStatus InstanceRevertResize     = True
 billableStatus InstancePaused           = False
 billableStatus InstanceSuspended        = False
 billableStatus InstanceRescue           = False
-billableStatus InstanceMigrating        = False
+billableStatus InstanceMigrating        = True

--- a/lib/Borel/Chevalier.hs
+++ b/lib/Borel/Chevalier.hs
@@ -58,6 +58,7 @@ chevalier (metrics, tid) = do
 
 chevalierTags :: Set Metric -> (GroupedMetric, TenancyID) -> [(Text, Text)]
 chevalierTags instances (ms, TenancyID tid) = case ms of
+  []       -> []
   [metric] -> if
     | metric == cpu        -> [tagID tid , tagName "cpu"                                  ]
     | metric == volumes    -> [tagID tid , tagName "volume.size"            , tagEvent    ]

--- a/lib/Borel/Types/Metric.hs
+++ b/lib/Borel/Types/Metric.hs
@@ -39,7 +39,7 @@ data Metric = Metric
 
 mkInstance :: Flavor -> Metric
 mkInstance name = Metric
-  { deserialise      = "instances/" <> name
+  { deserialise      = "instances-" <> name
   , pretty           = "instance-"  <> name <> "-allocation"
   , uom              = countInstance `Times` nanosec
   }
@@ -63,13 +63,13 @@ diskWrites           = Metric
   }
 
 neutronIn            = Metric
-  { deserialise      = "neutron-traffic/incoming"
+  { deserialise      = "neutron-traffic-incoming"
   , pretty           = "neutron-data-rx"
   , uom              = byte
   }
 
 neutronOut           = Metric
-  { deserialise      = "neutron-traffic/outgoing"
+  { deserialise      = "neutron-traffic-outgoing"
   , pretty           = "neutron-data-tx"
   , uom              = byte
   }


### PR DESCRIPTION
Requires: https://github.com/anchor/ceilometer-common/pull/10

Updates the Env supplied to ceilometer-common to include a predicate to filter instance statuses.

Makes minor deserialising changes ('/' -> '-')
groupMetrics no longer inserts an empty list into the Set of GroupMetrics it returns if none of the given metrics match anything in instances.