### PR TITLE
update groupMetrics to not insert and empty list if no metrics are instances

### DIFF
--- a/borel-core.cabal
+++ b/borel-core.cabal
@@ -1,5 +1,5 @@
 name:                borel-core
-version:             0.17.0
+version:             0.17.1
 synopsis:            Metering System for OpenStack metrics provided by Vaultaire.
 description:         Leverages Ceilometer, Chevalier and Marquise to meter OpenStack data.
 homepage:            https://github.com/anchor/borel-core

--- a/lib/Borel.hs
+++ b/lib/Borel.hs
@@ -48,6 +48,7 @@ module Borel
   ) where
 
 import           Control.Applicative
+import           Control.Arrow
 import           Control.Lens
 import           Control.Monad.Reader
 import           Data.Set             (Set)
@@ -80,8 +81,10 @@ groupMetrics :: Set Metric        -- ^ All available instances
              -> Set Metric        -- ^ Metrics to be grouped
              -> Set GroupedMetric
 groupMetrics instances metrics
-  =  let (allfs, nonfs) = _1 %~ S.toList $ S.partition (`S.member` instances) metrics
-     in  S.insert allfs $ S.map pure nonfs
+  =  let (allfs, nonfs) = (S.toList *** S.map pure) $ S.partition (`S.member` instances) metrics
+     in case allfs of
+       [] -> nonfs
+       xs -> S.insert xs nonfs
 
 
 --------------------------------------------------------------------------------

--- a/lib/Borel.hs
+++ b/lib/Borel.hs
@@ -48,7 +48,6 @@ module Borel
   ) where
 
 import           Control.Applicative
-import           Control.Arrow
 import           Control.Lens
 import           Control.Monad.Reader
 import           Data.Set             (Set)
@@ -81,10 +80,13 @@ groupMetrics :: Set Metric        -- ^ All available instances
              -> Set Metric        -- ^ Metrics to be grouped
              -> Set GroupedMetric
 groupMetrics instances metrics
-  =  let (allfs, nonfs) = (S.toList *** S.map pure) $ S.partition (`S.member` instances) metrics
-     in case allfs of
-       [] -> nonfs
-       xs -> S.insert xs nonfs
+  =  if S.null metrics then
+        S.singleton [] --Empty set of resources -> empty list of resources -> all resources query
+     else
+        let (allfs, nonfs) = bimap S.toList (S.map pure) $ S.partition (`S.member` instances) metrics
+        in case allfs of
+            [] -> nonfs
+            xs -> S.insert xs nonfs
 
 
 --------------------------------------------------------------------------------

--- a/lib/Borel/Chevalier.hs
+++ b/lib/Borel/Chevalier.hs
@@ -56,9 +56,11 @@ chevalier (metrics, tid) = do
                              (C.buildRequestFromPairs tags)
     ]
 
+-- | Converts a GroupedMetric and a TenancyID into a list of cheavlier tags
+--   Also requires a set of the currently configured instance flavors
 chevalierTags :: Set Metric -> (GroupedMetric, TenancyID) -> [(Text, Text)]
 chevalierTags instances (ms, TenancyID tid) = case ms of
-  []       -> []
+  []       -> [tagID tid] --Query for all resources
   [metric] -> if
     | metric == cpu        -> [tagID tid , tagName "cpu"                                  ]
     | metric == block      -> [tagID tid , tagName "volume.size", tagBlock  , tagEvent    ]


### PR DESCRIPTION
As part of generating the Set of GroupedMetrics([Metric]) queried, the input list if partitioned into those which match an instance metric and those that do not. If there are no instance metrics whatsoever, an empty GroupedMetrics is inserted into the Set. When an empty list is passed to chevalierTags, it treats it like a query for all resources. The empty list is no longer inserted.

chevalierTags has also had a minor update to include the tenancy id in the generated list of chevalier tags.

@fractalcat @tranma 